### PR TITLE
URBNBorders

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,26 +7,27 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		00B6555EDDB0BA3C090BDB36F83AF38A /* QRCodeGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9542A56384F4BA87C0B8077A7015BA6 /* QRCodeGenerator.swift */; };
+		02618C3EC0ABF87DF23BBBC200210567 /* UIColorConvenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86D34B70082D21268DAEC0C245E85E7C /* UIColorConvenience.swift */; };
 		0A43A818B511F7E791DBBAA79C35210A /* Pods-URBNSwiftyConvenience_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 274753C4272E3AF44444E02BD5382149 /* Pods-URBNSwiftyConvenience_Example-dummy.m */; };
 		1CE146BD73C1FDB4B27A17756198F2DB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6604A7D69453B4569E4E4827FB9155A9 /* Foundation.framework */; };
-		4B0D3B2228EEA0DC7165DE8C14B2FE57 /* NotificationConvenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E9822D496502C2AAB1A92D42C6892C4 /* NotificationConvenience.swift */; };
-		536CF882D6C90DDAD678E5BD698E19CA /* LayoutConvenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7260947A0A7C63D112AFD7635436D2 /* LayoutConvenience.swift */; };
+		257D51654A67EA3EDE848DF302B84D9D /* URBNBorders.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1FD2D95E8FBDECB833789968422B43 /* URBNBorders.swift */; };
+		340A77E857BB30467CA033CFBCC09002 /* DictionaryConvenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDAFB22D4E23604D353CDB907B08E691 /* DictionaryConvenience.swift */; };
+		46F639A735B977C1722BA91E3A5AEA1D /* UIImageConvenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFD2D6A5FE326F236607F89CD7E9504 /* UIImageConvenience.swift */; };
+		499DBFD49DF1DE7DA55DF97BDCD9F650 /* URBNSwiftyConvenience-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = AA5A55E7C2AE76EB265C186CBF5DD96D /* URBNSwiftyConvenience-dummy.m */; };
+		542207B7EBFE5A589B3DE113A24D7A3F /* SearchableProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D339B178E302553FDC8920CDDECA72 /* SearchableProtocol.swift */; };
 		566F4BC845C73C850D1EA368A1C2A66B /* URBNSwiftyConvenience-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = AD58FE0133C9E0A6BDEFF869814F7715 /* URBNSwiftyConvenience-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5897537B68852892DA50B9832D188D0E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6604A7D69453B4569E4E4827FB9155A9 /* Foundation.framework */; };
-		64017C434D3F93A3D5D8561AADE9295C /* ResultType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48EAAC1D6F678C884DFB8F002F172E05 /* ResultType.swift */; };
-		6B34C5CC86C3F437D7865118C14365F8 /* DictionaryConvenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D54C2750BD9F279A03C65B031AA270 /* DictionaryConvenience.swift */; };
-		6EE1E33D3677D4ABA7DD8290CDADF1DC /* CollectionViewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 197F07524952AE5AF1839D84B783BDCC /* CollectionViewHelpers.swift */; };
-		82E6BC93BC9B1456B7AE0FEB392D220D /* SearchableProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD701E551F0B5DBDAC004A6D78DAA6D8 /* SearchableProtocol.swift */; };
-		8ACD75D4DC55B5CD7DC5395EEEDAFC95 /* URBNSwiftyConvenience-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = AA5A55E7C2AE76EB265C186CBF5DD96D /* URBNSwiftyConvenience-dummy.m */; };
-		8DB39B0CB419AFDE906756626DF03192 /* UIColorConvenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = A113E9AA29A141C0F7C1E948F1531A06 /* UIColorConvenience.swift */; };
+		63F8A94CD0416CBBA27266B8E5865BFB /* LayoutConvenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5D5C831128F67447BEDEFE27FD2160E /* LayoutConvenience.swift */; };
+		993D9B083D3C00AA539ABE6828086E2F /* DateConvenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B06BB2141BE8CD0BE73CED2D02E4DB3 /* DateConvenience.swift */; };
+		9ECBF79DD625D0DDC472AEFF53FB06BF /* TableViewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7854B03CB2BDA70A1FC3FD88A5534331 /* TableViewHelpers.swift */; };
 		9FB2755E535A3592560C71BC178DFDDC /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6604A7D69453B4569E4E4827FB9155A9 /* Foundation.framework */; };
+		A6EBFB19511E774AEA621EB7A5C6686D /* ResultType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2998A012E02DCFE02B0367692BFD5F76 /* ResultType.swift */; };
 		ADB840CC9774E5C86D4966B7C4EF14E9 /* Pods-URBNSwiftyConvenience_Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BBF682516806EE15286F31938EF49EB /* Pods-URBNSwiftyConvenience_Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C607AE4272EDC8E5D92506AFFC35639A /* Pods-URBNSwiftyConvenience_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 59AC2E4D686E6E22125A9CB825FCCB94 /* Pods-URBNSwiftyConvenience_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C683D22EA3D89FF969935AB6FA9E4FF6 /* UIImageConvenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD9EDAEA119948289C2479EDC01B902E /* UIImageConvenience.swift */; };
 		D66281739333A2BCF6D40AD1AC469C3C /* Pods-URBNSwiftyConvenience_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 99A7CB59776FF41DDBB940B3DF86625F /* Pods-URBNSwiftyConvenience_Tests-dummy.m */; };
-		D99A5C0DA0D945F3D4B0CE6CA9EA4FF5 /* TableViewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A17AC3CE94C65CCE208C7C0B23642ED /* TableViewHelpers.swift */; };
-		E1A9D96E8EAD40C1BE95333CE3080F79 /* DateConvenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F959D174315C4194A72D325132A0AC /* DateConvenience.swift */; };
+		F5E5EAFB71362AD010B4D3A43911BDEE /* NotificationConvenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 386BE0CB241C2D87F621B891BFF2E7FE /* NotificationConvenience.swift */; };
+		F61B26C0591D2D85C9BC13E248E746C9 /* CollectionViewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3755F53B0883F7AB363153861EA61B2D /* CollectionViewHelpers.swift */; };
+		FF059C13BCF7CC392C3CB656D5F1DC72 /* QRCodeGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4031AFDD7B928DB64A1DAFE065B9AE3 /* QRCodeGenerator.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -40,31 +41,31 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		197F07524952AE5AF1839D84B783BDCC /* CollectionViewHelpers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CollectionViewHelpers.swift; sourceTree = "<group>"; };
-		1E9822D496502C2AAB1A92D42C6892C4 /* NotificationConvenience.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotificationConvenience.swift; sourceTree = "<group>"; };
 		21CBF23141AC3ED7EF3AD19A459530DF /* URBNSwiftyConvenience-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "URBNSwiftyConvenience-prefix.pch"; sourceTree = "<group>"; };
 		274753C4272E3AF44444E02BD5382149 /* Pods-URBNSwiftyConvenience_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-URBNSwiftyConvenience_Example-dummy.m"; sourceTree = "<group>"; };
+		2998A012E02DCFE02B0367692BFD5F76 /* ResultType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ResultType.swift; sourceTree = "<group>"; };
+		3755F53B0883F7AB363153861EA61B2D /* CollectionViewHelpers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CollectionViewHelpers.swift; sourceTree = "<group>"; };
+		386BE0CB241C2D87F621B891BFF2E7FE /* NotificationConvenience.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotificationConvenience.swift; sourceTree = "<group>"; };
 		3AFEABA5D56CBF8EF2A87FE1CA187F75 /* URBNSwiftyConvenience.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = URBNSwiftyConvenience.framework; path = URBNSwiftyConvenience.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B5864F15002767DB941346E9C92ADF0 /* Pods-URBNSwiftyConvenience_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "Pods-URBNSwiftyConvenience_Example.modulemap"; sourceTree = "<group>"; };
 		41AE7E544D662E4CC0527524CB67556D /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		450516AB19421DFC69B8DF55142FD1D3 /* Pods_URBNSwiftyConvenience_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_URBNSwiftyConvenience_Example.framework; path = "Pods-URBNSwiftyConvenience_Example.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		46D7B3CC0C408DD694DBB8C0ED6EE9EB /* Pods-URBNSwiftyConvenience_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-URBNSwiftyConvenience_Example.release.xcconfig"; sourceTree = "<group>"; };
-		48EAAC1D6F678C884DFB8F002F172E05 /* ResultType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ResultType.swift; sourceTree = "<group>"; };
+		4B06BB2141BE8CD0BE73CED2D02E4DB3 /* DateConvenience.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DateConvenience.swift; sourceTree = "<group>"; };
 		52C7CEE1B8D4B976D264CFE42376A2D2 /* Pods-URBNSwiftyConvenience_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-URBNSwiftyConvenience_Example-acknowledgements.plist"; sourceTree = "<group>"; };
 		59AC2E4D686E6E22125A9CB825FCCB94 /* Pods-URBNSwiftyConvenience_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-URBNSwiftyConvenience_Example-umbrella.h"; sourceTree = "<group>"; };
-		5E7260947A0A7C63D112AFD7635436D2 /* LayoutConvenience.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LayoutConvenience.swift; sourceTree = "<group>"; };
+		65D339B178E302553FDC8920CDDECA72 /* SearchableProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SearchableProtocol.swift; sourceTree = "<group>"; };
 		6604A7D69453B4569E4E4827FB9155A9 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		6A17AC3CE94C65CCE208C7C0B23642ED /* TableViewHelpers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TableViewHelpers.swift; sourceTree = "<group>"; };
 		6F6C2C81AE788DDD17B3A0D166D08D78 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		7854B03CB2BDA70A1FC3FD88A5534331 /* TableViewHelpers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TableViewHelpers.swift; sourceTree = "<group>"; };
 		7BB59BF29B60F7CD428E8FF4EFE777FF /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7BC9EBD23959136F6F937BADBD657D75 /* Pods-URBNSwiftyConvenience_Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-URBNSwiftyConvenience_Tests-acknowledgements.plist"; sourceTree = "<group>"; };
+		86D34B70082D21268DAEC0C245E85E7C /* UIColorConvenience.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UIColorConvenience.swift; sourceTree = "<group>"; };
 		8BBF682516806EE15286F31938EF49EB /* Pods-URBNSwiftyConvenience_Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-URBNSwiftyConvenience_Tests-umbrella.h"; sourceTree = "<group>"; };
-		90F959D174315C4194A72D325132A0AC /* DateConvenience.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DateConvenience.swift; sourceTree = "<group>"; };
 		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		99A7CB59776FF41DDBB940B3DF86625F /* Pods-URBNSwiftyConvenience_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-URBNSwiftyConvenience_Tests-dummy.m"; sourceTree = "<group>"; };
 		9EE37D7E72C13D17DD9F2CB29AFE853F /* URBNSwiftyConvenience.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = URBNSwiftyConvenience.modulemap; sourceTree = "<group>"; };
 		9F7FF6D5557CACD4F94E468584A7F13E /* Pods-URBNSwiftyConvenience_Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "Pods-URBNSwiftyConvenience_Tests.modulemap"; sourceTree = "<group>"; };
-		A113E9AA29A141C0F7C1E948F1531A06 /* UIColorConvenience.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UIColorConvenience.swift; sourceTree = "<group>"; };
 		A325A03535547DBA4EA7508514051CDD /* Pods-URBNSwiftyConvenience_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-URBNSwiftyConvenience_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
 		A3453E182CF91383B39278C4FF25D0B5 /* Pods-URBNSwiftyConvenience_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-URBNSwiftyConvenience_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		A4CA04B53E6848E12A60792081323CB3 /* Pods-URBNSwiftyConvenience_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-URBNSwiftyConvenience_Example.debug.xcconfig"; sourceTree = "<group>"; };
@@ -74,14 +75,15 @@
 		AB14A08FA92EFEF7CC5DE0909B001182 /* Pods-URBNSwiftyConvenience_Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-URBNSwiftyConvenience_Tests-frameworks.sh"; sourceTree = "<group>"; };
 		AC094B8AD489CE1F1AD5BA5D45054FEE /* Pods-URBNSwiftyConvenience_Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-URBNSwiftyConvenience_Example-resources.sh"; sourceTree = "<group>"; };
 		AD58FE0133C9E0A6BDEFF869814F7715 /* URBNSwiftyConvenience-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "URBNSwiftyConvenience-umbrella.h"; sourceTree = "<group>"; };
-		AD9EDAEA119948289C2479EDC01B902E /* UIImageConvenience.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UIImageConvenience.swift; sourceTree = "<group>"; };
 		BA28A9D79ABBDA87BB5E51273FE3A4FE /* Pods-URBNSwiftyConvenience_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-URBNSwiftyConvenience_Example-frameworks.sh"; sourceTree = "<group>"; };
 		C057D993B45A745DE2F0E234F9E92E8D /* Pods-URBNSwiftyConvenience_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-URBNSwiftyConvenience_Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		C4D54C2750BD9F279A03C65B031AA270 /* DictionaryConvenience.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DictionaryConvenience.swift; sourceTree = "<group>"; };
+		CCFD2D6A5FE326F236607F89CD7E9504 /* UIImageConvenience.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UIImageConvenience.swift; sourceTree = "<group>"; };
+		E4031AFDD7B928DB64A1DAFE065B9AE3 /* QRCodeGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QRCodeGenerator.swift; sourceTree = "<group>"; };
+		E5D5C831128F67447BEDEFE27FD2160E /* LayoutConvenience.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LayoutConvenience.swift; sourceTree = "<group>"; };
 		E9433D1612E24E75DC23A75306E1EB9D /* Pods-URBNSwiftyConvenience_Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-URBNSwiftyConvenience_Tests-resources.sh"; sourceTree = "<group>"; };
-		E9542A56384F4BA87C0B8077A7015BA6 /* QRCodeGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QRCodeGenerator.swift; sourceTree = "<group>"; };
+		EDAFB22D4E23604D353CDB907B08E691 /* DictionaryConvenience.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DictionaryConvenience.swift; sourceTree = "<group>"; };
 		F6A41FF5435F89D628CA9B9F01CFF3B4 /* Pods_URBNSwiftyConvenience_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_URBNSwiftyConvenience_Tests.framework; path = "Pods-URBNSwiftyConvenience_Tests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FD701E551F0B5DBDAC004A6D78DAA6D8 /* SearchableProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SearchableProtocol.swift; sourceTree = "<group>"; };
+		FB1FD2D95E8FBDECB833789968422B43 /* URBNBorders.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = URBNBorders.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -112,25 +114,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		2078E970A48F865C5F6112B72B9C4B9C /* Classes */ = {
-			isa = PBXGroup;
-			children = (
-				197F07524952AE5AF1839D84B783BDCC /* CollectionViewHelpers.swift */,
-				90F959D174315C4194A72D325132A0AC /* DateConvenience.swift */,
-				C4D54C2750BD9F279A03C65B031AA270 /* DictionaryConvenience.swift */,
-				5E7260947A0A7C63D112AFD7635436D2 /* LayoutConvenience.swift */,
-				1E9822D496502C2AAB1A92D42C6892C4 /* NotificationConvenience.swift */,
-				E9542A56384F4BA87C0B8077A7015BA6 /* QRCodeGenerator.swift */,
-				48EAAC1D6F678C884DFB8F002F172E05 /* ResultType.swift */,
-				FD701E551F0B5DBDAC004A6D78DAA6D8 /* SearchableProtocol.swift */,
-				6A17AC3CE94C65CCE208C7C0B23642ED /* TableViewHelpers.swift */,
-				A113E9AA29A141C0F7C1E948F1531A06 /* UIColorConvenience.swift */,
-				AD9EDAEA119948289C2479EDC01B902E /* UIImageConvenience.swift */,
-			);
-			name = Classes;
-			path = Classes;
-			sourceTree = "<group>";
-		};
 		4CC2BAA82F4BC231216FFDF480FD0E81 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -145,7 +128,7 @@
 			isa = PBXGroup;
 			children = (
 				CFA2CAFB4CE0851131862CB67712286B /* Support Files */,
-				989135E537E9E6A8227C5C1FA98AF071 /* URBNSwiftyConvenience */,
+				C0E718D95F5921FB224DEF3693782070 /* URBNSwiftyConvenience */,
 			);
 			name = URBNSwiftyConvenience;
 			path = ../..;
@@ -160,15 +143,6 @@
 				4CC2BAA82F4BC231216FFDF480FD0E81 /* Products */,
 				EB46B72C87F8CA5BC2B6174F31D751EC /* Targets Support Files */,
 			);
-			sourceTree = "<group>";
-		};
-		989135E537E9E6A8227C5C1FA98AF071 /* URBNSwiftyConvenience */ = {
-			isa = PBXGroup;
-			children = (
-				2078E970A48F865C5F6112B72B9C4B9C /* Classes */,
-			);
-			name = URBNSwiftyConvenience;
-			path = URBNSwiftyConvenience;
 			sourceTree = "<group>";
 		};
 		98BB56C9B060CDE9B2FEC0F4C1839ADA /* Development Pods */ = {
@@ -197,12 +171,41 @@
 			path = "Target Support Files/Pods-URBNSwiftyConvenience_Example";
 			sourceTree = "<group>";
 		};
+		A89EC6E3CBE25A8CBAF9F7AC4BFE231D /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				3755F53B0883F7AB363153861EA61B2D /* CollectionViewHelpers.swift */,
+				4B06BB2141BE8CD0BE73CED2D02E4DB3 /* DateConvenience.swift */,
+				EDAFB22D4E23604D353CDB907B08E691 /* DictionaryConvenience.swift */,
+				E5D5C831128F67447BEDEFE27FD2160E /* LayoutConvenience.swift */,
+				386BE0CB241C2D87F621B891BFF2E7FE /* NotificationConvenience.swift */,
+				E4031AFDD7B928DB64A1DAFE065B9AE3 /* QRCodeGenerator.swift */,
+				2998A012E02DCFE02B0367692BFD5F76 /* ResultType.swift */,
+				65D339B178E302553FDC8920CDDECA72 /* SearchableProtocol.swift */,
+				7854B03CB2BDA70A1FC3FD88A5534331 /* TableViewHelpers.swift */,
+				86D34B70082D21268DAEC0C245E85E7C /* UIColorConvenience.swift */,
+				CCFD2D6A5FE326F236607F89CD7E9504 /* UIImageConvenience.swift */,
+				FB1FD2D95E8FBDECB833789968422B43 /* URBNBorders.swift */,
+			);
+			name = Classes;
+			path = Classes;
+			sourceTree = "<group>";
+		};
 		BC3CA7F9E30CC8F7E2DD044DD34432FC /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
 				D35AF013A5F0BAD4F32504907A52519E /* iOS */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		C0E718D95F5921FB224DEF3693782070 /* URBNSwiftyConvenience */ = {
+			isa = PBXGroup;
+			children = (
+				A89EC6E3CBE25A8CBAF9F7AC4BFE231D /* Classes */,
+			);
+			name = URBNSwiftyConvenience;
+			path = URBNSwiftyConvenience;
 			sourceTree = "<group>";
 		};
 		CFA2CAFB4CE0851131862CB67712286B /* Support Files */ = {
@@ -288,7 +291,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = AB094134F916CE5AEA6D44DDF2DC7129 /* Build configuration list for PBXNativeTarget "URBNSwiftyConvenience" */;
 			buildPhases = (
-				94ACB6CB354ACFE87675B44171F12ACC /* Sources */,
+				D334866C7BD89891F90406E9EDD6A28C /* Sources */,
 				D470C67E1B5CFB685B0E93856042A97E /* Frameworks */,
 				2DBB27C2F9012C14C498E9DCA6970A25 /* Headers */,
 			);
@@ -381,22 +384,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		94ACB6CB354ACFE87675B44171F12ACC /* Sources */ = {
+		D334866C7BD89891F90406E9EDD6A28C /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6EE1E33D3677D4ABA7DD8290CDADF1DC /* CollectionViewHelpers.swift in Sources */,
-				E1A9D96E8EAD40C1BE95333CE3080F79 /* DateConvenience.swift in Sources */,
-				6B34C5CC86C3F437D7865118C14365F8 /* DictionaryConvenience.swift in Sources */,
-				536CF882D6C90DDAD678E5BD698E19CA /* LayoutConvenience.swift in Sources */,
-				4B0D3B2228EEA0DC7165DE8C14B2FE57 /* NotificationConvenience.swift in Sources */,
-				00B6555EDDB0BA3C090BDB36F83AF38A /* QRCodeGenerator.swift in Sources */,
-				64017C434D3F93A3D5D8561AADE9295C /* ResultType.swift in Sources */,
-				82E6BC93BC9B1456B7AE0FEB392D220D /* SearchableProtocol.swift in Sources */,
-				D99A5C0DA0D945F3D4B0CE6CA9EA4FF5 /* TableViewHelpers.swift in Sources */,
-				8DB39B0CB419AFDE906756626DF03192 /* UIColorConvenience.swift in Sources */,
-				C683D22EA3D89FF969935AB6FA9E4FF6 /* UIImageConvenience.swift in Sources */,
-				8ACD75D4DC55B5CD7DC5395EEEDAFC95 /* URBNSwiftyConvenience-dummy.m in Sources */,
+				F61B26C0591D2D85C9BC13E248E746C9 /* CollectionViewHelpers.swift in Sources */,
+				993D9B083D3C00AA539ABE6828086E2F /* DateConvenience.swift in Sources */,
+				340A77E857BB30467CA033CFBCC09002 /* DictionaryConvenience.swift in Sources */,
+				63F8A94CD0416CBBA27266B8E5865BFB /* LayoutConvenience.swift in Sources */,
+				F5E5EAFB71362AD010B4D3A43911BDEE /* NotificationConvenience.swift in Sources */,
+				FF059C13BCF7CC392C3CB656D5F1DC72 /* QRCodeGenerator.swift in Sources */,
+				A6EBFB19511E774AEA621EB7A5C6686D /* ResultType.swift in Sources */,
+				542207B7EBFE5A589B3DE113A24D7A3F /* SearchableProtocol.swift in Sources */,
+				9ECBF79DD625D0DDC472AEFF53FB06BF /* TableViewHelpers.swift in Sources */,
+				02618C3EC0ABF87DF23BBBC200210567 /* UIColorConvenience.swift in Sources */,
+				46F639A735B977C1722BA91E3A5AEA1D /* UIImageConvenience.swift in Sources */,
+				257D51654A67EA3EDE848DF302B84D9D /* URBNBorders.swift in Sources */,
+				499DBFD49DF1DE7DA55DF97BDCD9F650 /* URBNSwiftyConvenience-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/URBNSwiftyConvenience/Classes/URBNBorders.swift
+++ b/URBNSwiftyConvenience/Classes/URBNBorders.swift
@@ -9,27 +9,33 @@
 import Foundation
 
 public class URBNBorder: NSObject {
-    let color = UIColor()
-    let width = CGFloat()
-    let insets = UIEdgeInsets()
+    public let color = UIColor()
+    public let width = CGFloat()
+    public let insets = UIEdgeInsets()
 }
 
 fileprivate class URBNBorderView: UIView {
-    private var urbn_leftBorder: URBNBorder?
-    private var urbn_rightBorder: URBNBorder?
-    private var urbn_topBorder: URBNBorder?
-    private var urbn_bottomBorder: URBNBorder?
+    private var leftBorder: URBNBorder?
+    private var rightBorder: URBNBorder?
+    private var topBorder: URBNBorder?
+    private var bottomBorder: URBNBorder?
     
     private final let width = "width"
     private final let color = "color"
     private final let insets = "insets"
+    
+    fileprivate let kURBNorderViewKey = CChar()
+    
+    convenience init() {
+        self.init()
+    }
     
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
     // MARK: KVO
-    func configuredBorder() -> URBNBorder {
+    private func configuredBorder() -> URBNBorder {
         let border = URBNBorder()
         border.addObserver(self, forKeyPath: width, options: .new, context: nil)
         border.addObserver(self, forKeyPath: color, options: .new, context: nil)
@@ -38,7 +44,7 @@ fileprivate class URBNBorderView: UIView {
         return border
     }
     
-    func unregisterKVO(forBorder border: URBNBorder) {
+    private func unregisterKVO(forBorder border: URBNBorder) {
         border.removeObserver(self, forKeyPath: width)
         border.removeObserver(self, forKeyPath: color)
         border.removeObserver(self, forKeyPath: insets)
@@ -49,12 +55,12 @@ fileprivate class URBNBorderView: UIView {
     }
     
     // MARK: Clear
-    func clearAllBorders() {
+    private func clearAllBorders() {
         guard
-            let leftBorder = urbn_leftBorder,
-            let rightBorder = urbn_rightBorder,
-            let topBorder = urbn_topBorder,
-            let bottomBorder = urbn_bottomBorder else {
+            let leftBorder = self.leftBorder,
+            let rightBorder = self.rightBorder,
+            let topBorder = self.topBorder,
+            let bottomBorder = self.bottomBorder else {
                 return
         }
         
@@ -63,40 +69,40 @@ fileprivate class URBNBorderView: UIView {
         unregisterKVO(forBorder: topBorder)
         unregisterKVO(forBorder: bottomBorder)
         
-        urbn_leftBorder = nil
-        urbn_rightBorder = nil
-        urbn_topBorder = nil
-        urbn_bottomBorder = nil
+        self.leftBorder = nil
+        self.rightBorder = nil
+        self.topBorder = nil
+        self.bottomBorder = nil
     }
     
-    func urbn_resetBorders() {
+    private func urbn_resetBorders() {
         clearAllBorders()
         setNeedsDisplay()
     }
     
     // MARK: Border Check for Nil
-    func urbn_LeftBorder() -> URBNBorder? {
+    private func urbn_LeftBorder() -> URBNBorder? {
         guard var leftBorder = urbn_leftBorder else { return nil }
         leftBorder = configuredBorder()
         
         return leftBorder
     }
     
-    func urbn_RightBorder() -> URBNBorder? {
+    private func urbn_RightBorder() -> URBNBorder? {
         guard var rightBorder = urbn_rightBorder else { return nil }
         rightBorder = configuredBorder()
         
         return rightBorder
     }
     
-    func urbn_TopBorder() -> URBNBorder? {
+    private func urbn_TopBorder() -> URBNBorder? {
         guard var topBorder = urbn_topBorder else { return nil }
         topBorder = configuredBorder()
         
         return topBorder
     }
     
-    func urbn_BottomBorder() -> URBNBorder? {
+    private func urbn_BottomBorder() -> URBNBorder? {
         guard var bottomBorder = urbn_bottomBorder else { return nil }
         bottomBorder = configuredBorder()
         
@@ -104,19 +110,19 @@ fileprivate class URBNBorderView: UIView {
     }
     
     // MARK: Drawing
-    func renderingScaleFactor() -> CGFloat? {
+    private func renderingScaleFactor() -> CGFloat? {
         if window?.screen.nativeScale != nil {
             return contentScaleFactor
         }
         return nil
     }
     
-    func upscaleTransform() -> CGAffineTransform? {
+    private func upscaleTransform() -> CGAffineTransform? {
         guard let scaleFactor = renderingScaleFactor() else { return nil }
         return CGAffineTransform(scaleX: scaleFactor, y: scaleFactor)
     }
     
-    func downscaleTransform() -> CGAffineTransform? {
+    private func downscaleTransform() -> CGAffineTransform? {
         guard let upscale = upscaleTransform() else { return nil }
         return upscale.inverted()
     }
@@ -124,10 +130,10 @@ fileprivate class URBNBorderView: UIView {
     override func draw(_ rect: CGRect) {
         guard
             let upscale = upscaleTransform(),
-            let leftBorder = urbn_leftBorder,
-            let rightBorder = urbn_rightBorder,
-            let topBorder = urbn_topBorder,
-            let bottomBorder = urbn_bottomBorder else {
+            let leftBorder = leftBorder,
+            let rightBorder = rightBorder,
+            let topBorder = topBorder,
+            let bottomBorder = bottomBorder else {
                 return
         }
         let viewRect = rect.applying(upscale)
@@ -169,7 +175,7 @@ fileprivate class URBNBorderView: UIView {
         }
     }
     
-    func drawBorder(_ border: URBNBorder, _ start: CGPoint, _ end: CGPoint) -> () {
+    private func drawBorder(_ border: URBNBorder, _ start: CGPoint, _ end: CGPoint) -> () {
         guard
             let renderingScale = renderingScaleFactor(),
             let downscale = downscaleTransform() else {
@@ -184,7 +190,7 @@ fileprivate class URBNBorderView: UIView {
         path.stroke()
     }
     
-    func borderDrawBlock(_ border: URBNBorder, _ completion: (_ drawnBorder: URBNBorder) -> ()) -> () {
+    private func borderDrawBlock(_ border: URBNBorder, _ completion: (_ drawnBorder: URBNBorder) -> ()) -> () {
         guard let context = UIGraphicsGetCurrentContext() else { return }
         if border.width > 0 {
             context.saveGState()
@@ -197,4 +203,23 @@ fileprivate class URBNBorderView: UIView {
     deinit {
         clearAllBorders()
     }
+}
+
+extension UIView {
+    public var urbn_leftBorder: URBNBorder? {
+        return self.urbn_leftBorder != nil ? self.urbn_leftBorder : nil
+    }
+    
+    public var urbn_rightBorder: URBNBorder? {
+        return self.urbn_rightBorder != nil ? self.urbn_rightBorder : nil
+    }
+    
+    public var urbn_topBorder: URBNBorder? {
+        return self.urbn_topBorder != nil ? self.urbn_topBorder : nil
+    }
+    
+    public var urbn_bottomBorder: URBNBorder? {
+        return self.urbn_bottomBorder != nil ? self.urbn_bottomBorder : nil
+    }
+    
 }

--- a/URBNSwiftyConvenience/Classes/URBNBorders.swift
+++ b/URBNSwiftyConvenience/Classes/URBNBorders.swift
@@ -14,3 +14,13 @@ public class URBNBorder: NSObject {
     let insets = UIEdgeInsets()
 }
 
+fileprivate class URBNBorderView: UIView {
+    let urbn_leftBorder: URBNBorder?
+    let urbn_topBorder: URBNBorder?
+    let urbn_rightBorder: URBNBorder?
+    let urbn_bottomBorder: URBNBorder?
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/URBNSwiftyConvenience/Classes/URBNBorders.swift
+++ b/URBNSwiftyConvenience/Classes/URBNBorders.swift
@@ -73,4 +73,33 @@ fileprivate class URBNBorderView: UIView {
         clearAllBorders()
         setNeedsDisplay()
     }
+    
+    // MARK: Border Check for Nil
+    func urbn_LeftBorder() -> URBNBorder? {
+        guard var leftBorder = urbn_leftBorder else { return nil }
+        leftBorder = configuredBorder()
+
+        return leftBorder
+    }
+    
+    func urbn_RightBorder() -> URBNBorder? {
+        guard var rightBorder = urbn_rightBorder else { return nil }
+        rightBorder = configuredBorder()
+        
+        return rightBorder
+    }
+    
+    func urbn_TopBorder() -> URBNBorder? {
+        guard var topBorder = urbn_topBorder else { return nil }
+        topBorder = configuredBorder()
+        
+        return topBorder
+    }
+    
+    func urbn_BottomBorder() -> URBNBorder? {
+        guard var bottomBorder = urbn_bottomBorder else { return nil }
+        bottomBorder = configuredBorder()
+        
+        return bottomBorder
+    }
 }

--- a/URBNSwiftyConvenience/Classes/URBNBorders.swift
+++ b/URBNSwiftyConvenience/Classes/URBNBorders.swift
@@ -15,10 +15,10 @@ public class URBNBorder: NSObject {
 }
 
 fileprivate class URBNBorderView: UIView {
-    let urbn_leftBorder: URBNBorder?
-    let urbn_topBorder: URBNBorder?
-    let urbn_rightBorder: URBNBorder?
-    let urbn_bottomBorder: URBNBorder?
+    var urbn_leftBorder: URBNBorder?
+    var urbn_rightBorder: URBNBorder?
+    var urbn_topBorder: URBNBorder?
+    var urbn_bottomBorder: URBNBorder?
     
     private final let width = "width"
     private final let color = "color"
@@ -45,6 +45,32 @@ fileprivate class URBNBorderView: UIView {
     }
     
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+        setNeedsDisplay()
+    }
+    
+    // MARK: Clear
+    func clearAllBorders() {
+        guard
+            let leftBorder = urbn_leftBorder,
+            let rightBorder = urbn_rightBorder,
+            let topBorder = urbn_topBorder,
+            let bottomBorder = urbn_bottomBorder else {
+                return
+        }
+        
+        unregisterKVO(forBorder: leftBorder)
+        unregisterKVO(forBorder: rightBorder)
+        unregisterKVO(forBorder: topBorder)
+        unregisterKVO(forBorder: bottomBorder)
+        
+        urbn_leftBorder = nil
+        urbn_rightBorder = nil
+        urbn_topBorder = nil
+        urbn_bottomBorder = nil
+    }
+    
+    func urbn_resetBorders() {
+        clearAllBorders()
         setNeedsDisplay()
     }
 }

--- a/URBNSwiftyConvenience/Classes/URBNBorders.swift
+++ b/URBNSwiftyConvenience/Classes/URBNBorders.swift
@@ -17,10 +17,10 @@ public class URBNBorder: NSObject {
 }
 
 fileprivate class URBNBorderView: UIView {
-    private var leftBorder: URBNBorder?
-    private var rightBorder: URBNBorder?
-    private var topBorder: URBNBorder?
-    private var bottomBorder: URBNBorder?
+    fileprivate var bv_leftBorder: URBNBorder?
+    fileprivate var bv_rightBorder: URBNBorder?
+    fileprivate var bv_topBorder: URBNBorder?
+    fileprivate var bv_bottomBorder: URBNBorder?
     
     private final let width = "width"
     private final let color = "color"
@@ -61,10 +61,10 @@ fileprivate class URBNBorderView: UIView {
     // MARK: Clear
     private func clearAllBorders() {
         guard
-            let leftBorder = self.leftBorder,
-            let rightBorder = self.rightBorder,
-            let topBorder = self.topBorder,
-            let bottomBorder = self.bottomBorder else {
+            let leftBorder = self.bv_leftBorder,
+            let rightBorder = self.bv_rightBorder,
+            let topBorder = self.bv_topBorder,
+            let bottomBorder = self.bv_bottomBorder else {
                 return
         }
         
@@ -73,13 +73,13 @@ fileprivate class URBNBorderView: UIView {
         unregisterKVO(forBorder: topBorder)
         unregisterKVO(forBorder: bottomBorder)
         
-        self.leftBorder = nil
-        self.rightBorder = nil
-        self.topBorder = nil
-        self.bottomBorder = nil
+        self.bv_leftBorder = nil
+        self.bv_rightBorder = nil
+        self.bv_topBorder = nil
+        self.bv_bottomBorder = nil
     }
     
-    private func resetBorders() {
+    fileprivate func resetBorders() {
         clearAllBorders()
         setNeedsDisplay()
     }
@@ -134,10 +134,10 @@ fileprivate class URBNBorderView: UIView {
     override func draw(_ rect: CGRect) {
         guard
             let upscale = upscaleTransform(),
-            let leftBorder = leftBorder,
-            let rightBorder = rightBorder,
-            let topBorder = topBorder,
-            let bottomBorder = bottomBorder else {
+            let leftBorder = bv_leftBorder,
+            let rightBorder = bv_rightBorder,
+            let topBorder = bv_topBorder,
+            let bottomBorder = bv_bottomBorder else {
                 return
         }
         let viewRect = rect.applying(upscale)
@@ -211,19 +211,19 @@ fileprivate class URBNBorderView: UIView {
 
 extension UIView {
     public var urbn_leftBorder: URBNBorder? {
-        return self.urbn_leftBorder != nil ? self.urbn_leftBorder : nil
+        return self.urbn_leftBorder
     }
     
     public var urbn_rightBorder: URBNBorder? {
-        return self.urbn_rightBorder != nil ? self.urbn_rightBorder : nil
+        return self.urbn_rightBorder
     }
     
     public var urbn_topBorder: URBNBorder? {
-        return self.urbn_topBorder != nil ? self.urbn_topBorder : nil
+        return self.urbn_topBorder
     }
     
     public var urbn_bottomBorder: URBNBorder? {
-        return self.urbn_bottomBorder != nil ? self.urbn_bottomBorder : nil
+        return self.urbn_bottomBorder
     }
     
     private func urbn_borderView() -> URBNBorderView? {
@@ -252,7 +252,7 @@ extension UIView {
     }
     
     public func urbn_resetBorders() {
-        urbn_borderView()?.urbn_resetBorders()
+        urbn_borderView()?.resetBorders()
     }
     
     public func urbn_setBorder(withColor color: UIColor, width: CGFloat) {
@@ -266,4 +266,20 @@ extension UIView {
         urbn_bottomBorder?.color = color
     }
     
+    // MARK: Getters
+    private func leftBorder() -> URBNBorder? {
+        return self.urbn_borderView()?.bv_leftBorder
+    }
+    
+    private func rightBorder() -> URBNBorder? {
+        return self.urbn_borderView()?.bv_rightBorder
+    }
+    
+    private func topBorder() -> URBNBorder? {
+        return self.urbn_borderView()?.bv_topBorder
+    }
+    
+    private func bottomBorder() -> URBNBorder? {
+        return self.urbn_borderView()?.bv_bottomBorder
+    }
 }

--- a/URBNSwiftyConvenience/Classes/URBNBorders.swift
+++ b/URBNSwiftyConvenience/Classes/URBNBorders.swift
@@ -25,6 +25,21 @@ extension UIView {
         return bottomBorder()
     }
     
+    public func urbn_setBorder(withColor color: UIColor, width: CGFloat) {
+        urbn_leftBorder?.width = width
+        urbn_rightBorder?.width = width
+        urbn_topBorder?.width = width
+        urbn_bottomBorder?.width = width
+        urbn_leftBorder?.color = color
+        urbn_rightBorder?.color = color
+        urbn_topBorder?.color = color
+        urbn_bottomBorder?.color = color
+    }
+    
+    public func urbn_resetBorders() {
+        urbn_borderView()?.resetBorders()
+    }
+    
     private func urbn_borderView() -> URBNBorderView? {
         if var borderView = objc_getAssociatedObject(self, &kURBNorderViewKey) as? URBNBorderView {
             borderView = URBNBorderView(frame: self.bounds)
@@ -45,22 +60,7 @@ extension UIView {
         
         return nil
     }
-    
-    public func urbn_resetBorders() {
-        urbn_borderView()?.resetBorders()
-    }
-    
-    public func urbn_setBorder(withColor color: UIColor, width: CGFloat) {
-        urbn_leftBorder?.width = width
-        urbn_rightBorder?.width = width
-        urbn_topBorder?.width = width
-        urbn_bottomBorder?.width = width
-        urbn_leftBorder?.color = color
-        urbn_rightBorder?.color = color
-        urbn_topBorder?.color = color
-        urbn_bottomBorder?.color = color
-    }
-    
+
     // MARK: Getters
     private func leftBorder() -> URBNBorder? {
         return self.urbn_borderView()?.urbn_LeftBorder()
@@ -85,7 +85,7 @@ public class URBNBorder: NSObject {
     public let insets = UIEdgeInsets()
 }
 
-fileprivate class URBNBorderView: UIView {
+fileprivate final class URBNBorderView: UIView {
     fileprivate var bv_leftBorder: URBNBorder?
     fileprivate var bv_rightBorder: URBNBorder?
     fileprivate var bv_topBorder: URBNBorder?

--- a/URBNSwiftyConvenience/Classes/URBNBorders.swift
+++ b/URBNSwiftyConvenience/Classes/URBNBorders.swift
@@ -9,35 +9,35 @@
 import Foundation
 
 extension UIView {
-    public var urbn_leftBorder: URBNBorder? {
-        return leftBorder()
+    public var leftBorder: URBNBorder? {
+        return getLeftBorder()
     }
     
-    public var urbn_rightBorder: URBNBorder? {
-        return rightBorder()
+    public var rightBorder: URBNBorder? {
+        return getRightBorder()
     }
     
-    public var urbn_topBorder: URBNBorder? {
-        return topBorder()
+    public var topBorder: URBNBorder? {
+        return getTopBorder()
     }
     
-    public var urbn_bottomBorder: URBNBorder? {
-        return bottomBorder()
+    public var bottomBorder: URBNBorder? {
+        return getBottomBorder()
     }
     
-    public func urbn_setBorder(withColor color: UIColor, width: CGFloat) {
-        urbn_leftBorder?.width = width
-        urbn_rightBorder?.width = width
-        urbn_topBorder?.width = width
-        urbn_bottomBorder?.width = width
-        urbn_leftBorder?.color = color
-        urbn_rightBorder?.color = color
-        urbn_topBorder?.color = color
-        urbn_bottomBorder?.color = color
+    public func setBorder(withColor color: UIColor, width: CGFloat) {
+        leftBorder?.width = width
+        rightBorder?.width = width
+        topBorder?.width = width
+        bottomBorder?.width = width
+        leftBorder?.color = color
+        rightBorder?.color = color
+        topBorder?.color = color
+        bottomBorder?.color = color
     }
     
-    public func urbn_resetBorders() {
-        urbn_borderView()?.resetBorders()
+    public func resetBorders() {
+        urbn_borderView()?.urbn_resetBorders()
     }
     
     private func urbn_borderView() -> URBNBorderView? {
@@ -72,20 +72,20 @@ extension UIView {
     }
     
     // MARK: Getters
-    private func leftBorder() -> URBNBorder? {
-        return self.urbn_borderView()?.urbn_LeftBorder()
+    private func getLeftBorder() -> URBNBorder? {
+        return self.urbn_borderView()?.bv_leftBorder
     }
     
-    private func rightBorder() -> URBNBorder? {
-        return self.urbn_borderView()?.urbn_RightBorder()
+    private func getRightBorder() -> URBNBorder? {
+        return self.urbn_borderView()?.bv_rightBorder
     }
     
-    private func topBorder() -> URBNBorder? {
-        return self.urbn_borderView()?.urbn_TopBorder()
+    private func getTopBorder() -> URBNBorder? {
+        return self.urbn_borderView()?.bv_topBorder
     }
     
-    private func bottomBorder() -> URBNBorder? {
-        return self.urbn_borderView()?.urbn_BottomBorder()
+    private func getBottomBorder() -> URBNBorder? {
+        return self.urbn_borderView()?.bv_bottomBorder
     }
 }
 
@@ -96,10 +96,26 @@ public class URBNBorder: NSObject {
 }
 
 fileprivate final class URBNBorderView: UIView {
-    fileprivate var bv_leftBorder: URBNBorder?
-    fileprivate var bv_rightBorder: URBNBorder?
-    fileprivate var bv_topBorder: URBNBorder?
-    fileprivate var bv_bottomBorder: URBNBorder?
+    fileprivate var bv_leftBorder: URBNBorder? {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    fileprivate var bv_rightBorder: URBNBorder? {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    fileprivate var bv_topBorder: URBNBorder? {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    fileprivate var bv_bottomBorder: URBNBorder? {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
     
     private final let width = "width"
     private final let color = "color"
@@ -116,80 +132,18 @@ fileprivate final class URBNBorderView: UIView {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    // MARK: KVO
-    private func configuredBorder() -> URBNBorder {
-        let border = URBNBorder()
-        border.addObserver(self, forKeyPath: width, options: .new, context: nil)
-        border.addObserver(self, forKeyPath: color, options: .new, context: nil)
-        border.addObserver(self, forKeyPath: insets, options: .new, context: nil)
-        
-        return border
-    }
-    
-    private func unregisterKVO(forBorder border: URBNBorder) {
-        border.removeObserver(self, forKeyPath: width)
-        border.removeObserver(self, forKeyPath: color)
-        border.removeObserver(self, forKeyPath: insets)
-    }
-    
-    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
-        setNeedsDisplay()
-    }
-    
+
     // MARK: Clear
     private func clearAllBorders() {
-        guard
-            let leftBorder = bv_leftBorder,
-            let rightBorder = bv_rightBorder,
-            let topBorder = bv_topBorder,
-            let bottomBorder = bv_bottomBorder else {
-                return
-        }
-        
-        unregisterKVO(forBorder: leftBorder)
-        unregisterKVO(forBorder: rightBorder)
-        unregisterKVO(forBorder: topBorder)
-        unregisterKVO(forBorder: bottomBorder)
-        
-        bv_leftBorder = nil
-        bv_rightBorder = nil
-        bv_topBorder = nil
-        bv_bottomBorder = nil
+        objc_setAssociatedObject(bv_leftBorder, &kURBNBorderViewKey, nil, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        objc_setAssociatedObject(bv_rightBorder, &kURBNBorderViewKey, nil, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        objc_setAssociatedObject(bv_topBorder, &kURBNBorderViewKey, nil, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        objc_setAssociatedObject(bv_bottomBorder, &kURBNBorderViewKey, nil, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
     }
     
-    fileprivate func resetBorders() {
+    fileprivate func urbn_resetBorders() {
         clearAllBorders()
         setNeedsDisplay()
-    }
-    
-    // MARK: Border Check for Nil
-    fileprivate func urbn_LeftBorder() -> URBNBorder? {
-        guard var leftBorder = bv_leftBorder else { return nil }
-        leftBorder = configuredBorder()
-        
-        return leftBorder
-    }
-    
-    fileprivate func urbn_RightBorder() -> URBNBorder? {
-        guard var rightBorder = bv_rightBorder else { return nil }
-        rightBorder = configuredBorder()
-        
-        return rightBorder
-    }
-    
-    fileprivate func urbn_TopBorder() -> URBNBorder? {
-        guard var topBorder = bv_topBorder else { return nil }
-        topBorder = configuredBorder()
-        
-        return topBorder
-    }
-    
-    fileprivate func urbn_BottomBorder() -> URBNBorder? {
-        guard var bottomBorder = bv_bottomBorder else { return nil }
-        bottomBorder = configuredBorder()
-        
-        return bottomBorder
     }
     
     // MARK: Drawing

--- a/URBNSwiftyConvenience/Classes/URBNBorders.swift
+++ b/URBNSwiftyConvenience/Classes/URBNBorders.swift
@@ -1,0 +1,16 @@
+//
+//  URBNBorders.swift
+//  Pods
+//
+//  Created by Lloyd Sykes on 6/30/17.
+//
+//
+
+import Foundation
+
+public class URBNBorder: NSObject {
+    let color = UIColor()
+    let width = CGFloat()
+    let insets = UIEdgeInsets()
+}
+

--- a/URBNSwiftyConvenience/Classes/URBNBorders.swift
+++ b/URBNSwiftyConvenience/Classes/URBNBorders.swift
@@ -50,9 +50,18 @@ extension UIView {
             borderView.translatesAutoresizingMaskIntoConstraints = false
             self.addSubview(borderView)
             
-            let views = ["borderView" : borderView]
-            activateVFL(format: "V:|[borderView]|", options: .alignAllCenterX, metrics: nil, views: views)
-            activateVFL(format: "H:|[borderView]|", options: .alignAllCenterY, metrics: nil, views: views)
+            if #available(iOS 9.0, *) {
+                borderView.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
+                borderView.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
+                borderView.topAnchor.constraint(equalTo: topAnchor).isActive = true
+                borderView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
+            }
+            else {
+                let views = ["borderView" : borderView]
+                activateVFL(format: "V:|[borderView]|", options: .alignAllCenterX, metrics: nil, views: views)
+                activateVFL(format: "H:|[borderView]|", options: .alignAllCenterY, metrics: nil, views: views)
+            }
+
             objc_setAssociatedObject(self, &kURBNBorderViewKey, borderView, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
             
             return borderView

--- a/URBNSwiftyConvenience/Classes/URBNBorders.swift
+++ b/URBNSwiftyConvenience/Classes/URBNBorders.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 
+fileprivate var kURBNorderViewKey = CChar()
+
 public class URBNBorder: NSObject {
     public let color = UIColor()
     public let width = CGFloat()
@@ -23,11 +25,13 @@ fileprivate class URBNBorderView: UIView {
     private final let width = "width"
     private final let color = "color"
     private final let insets = "insets"
-    
-    fileprivate let kURBNorderViewKey = CChar()
-    
+
     convenience init() {
         self.init()
+    }
+    
+    override convenience init(frame: CGRect) {
+        self.init(frame: frame)
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -75,7 +79,7 @@ fileprivate class URBNBorderView: UIView {
         self.bottomBorder = nil
     }
     
-    private func urbn_resetBorders() {
+    private func resetBorders() {
         clearAllBorders()
         setNeedsDisplay()
     }
@@ -220,6 +224,39 @@ extension UIView {
     
     public var urbn_bottomBorder: URBNBorder? {
         return self.urbn_bottomBorder != nil ? self.urbn_bottomBorder : nil
+    }
+    
+    private func urbn_borderView() -> URBNBorderView? {
+        if self == URBNBorderView() {
+            return self as? URBNBorderView
+        }
+
+        if var borderView = objc_getAssociatedObject(self, &kURBNorderViewKey) as? URBNBorderView {
+            borderView = URBNBorderView(frame: self.bounds)
+            borderView.isOpaque = false
+            borderView.isUserInteractionEnabled = false
+            borderView.clearsContextBeforeDrawing = true
+            borderView.contentMode = .redraw
+            borderView.translatesAutoresizingMaskIntoConstraints = false
+            self.addSubview(borderView)
+            
+            let views = ["borderView" : borderView]
+            activateVFL(format: "V:|[borderView]|", options: .alignAllCenterX, metrics: nil, views: views)
+            activateVFL(format: "H:|[borderView]|", options: .alignAllCenterY, metrics: nil, views: views)
+            objc_setAssociatedObject(self, &kURBNorderViewKey, borderView, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            
+            return borderView
+        }
+
+        return nil
+    }
+    
+    public func urbn_resetBorders() {
+        
+    }
+    
+    public func urbn_setBorder(withColor color: UIColor, width: CGFloat) {
+        
     }
     
 }

--- a/URBNSwiftyConvenience/Classes/URBNBorders.swift
+++ b/URBNSwiftyConvenience/Classes/URBNBorders.swift
@@ -92,7 +92,7 @@ extension UIView {
 public class URBNBorder: NSObject {
     public var color = UIColor()
     public var width = CGFloat()
-    public let insets = UIEdgeInsets()
+    public var insets = UIEdgeInsets()
 }
 
 fileprivate final class URBNBorderView: UIView {

--- a/URBNSwiftyConvenience/Classes/URBNBorders.swift
+++ b/URBNSwiftyConvenience/Classes/URBNBorders.swift
@@ -41,7 +41,7 @@ extension UIView {
     }
     
     private func urbn_borderView() -> URBNBorderView? {
-        if var borderView = objc_getAssociatedObject(self, &kURBNorderViewKey) as? URBNBorderView {
+        if var borderView = objc_getAssociatedObject(self, &kURBNBorderViewKey) as? URBNBorderView {
             borderView = URBNBorderView(frame: self.bounds)
             borderView.isOpaque = false
             borderView.isUserInteractionEnabled = false
@@ -53,7 +53,7 @@ extension UIView {
             let views = ["borderView" : borderView]
             activateVFL(format: "V:|[borderView]|", options: .alignAllCenterX, metrics: nil, views: views)
             activateVFL(format: "H:|[borderView]|", options: .alignAllCenterY, metrics: nil, views: views)
-            objc_setAssociatedObject(self, &kURBNorderViewKey, borderView, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            objc_setAssociatedObject(self, &kURBNBorderViewKey, borderView, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
             
             return borderView
         }
@@ -278,4 +278,4 @@ fileprivate final class URBNBorderView: UIView {
     }
 }
 
-fileprivate var kURBNorderViewKey = CChar()
+fileprivate var kURBNBorderViewKey = CChar()

--- a/URBNSwiftyConvenience/Classes/URBNBorders.swift
+++ b/URBNSwiftyConvenience/Classes/URBNBorders.swift
@@ -193,4 +193,8 @@ fileprivate class URBNBorderView: UIView {
         context.restoreGState()
     }
     
+    // MARK: deinit
+    deinit {
+        clearAllBorders()
+    }
 }

--- a/URBNSwiftyConvenience/Classes/URBNBorders.swift
+++ b/URBNSwiftyConvenience/Classes/URBNBorders.swift
@@ -41,8 +41,12 @@ extension UIView {
     }
     
     private func urbn_borderView() -> URBNBorderView? {
-        if var borderView = objc_getAssociatedObject(self, &kURBNBorderViewKey) as? URBNBorderView {
-            borderView = URBNBorderView(frame: self.bounds)
+        if let existingBorderView = objc_getAssociatedObject(self, &kURBNBorderViewKey) as? URBNBorderView {
+            
+            return existingBorderView
+        }
+        else {
+            let borderView = URBNBorderView(frame: self.bounds)
             borderView.isOpaque = false
             borderView.isUserInteractionEnabled = false
             borderView.clearsContextBeforeDrawing = true
@@ -61,15 +65,12 @@ extension UIView {
                 activateVFL(format: "V:|[borderView]|", options: .alignAllCenterX, metrics: nil, views: views)
                 activateVFL(format: "H:|[borderView]|", options: .alignAllCenterY, metrics: nil, views: views)
             }
-
             objc_setAssociatedObject(self, &kURBNBorderViewKey, borderView, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
             
             return borderView
         }
-        
-        return nil
     }
-
+    
     // MARK: Getters
     private func leftBorder() -> URBNBorder? {
         return self.urbn_borderView()?.urbn_LeftBorder()

--- a/URBNSwiftyConvenience/Classes/URBNBorders.swift
+++ b/URBNSwiftyConvenience/Classes/URBNBorders.swift
@@ -8,7 +8,76 @@
 
 import Foundation
 
-fileprivate var kURBNorderViewKey = CChar()
+extension UIView {
+    public var urbn_leftBorder: URBNBorder? {
+        return leftBorder()
+    }
+    
+    public var urbn_rightBorder: URBNBorder? {
+        return rightBorder()
+    }
+    
+    public var urbn_topBorder: URBNBorder? {
+        return topBorder()
+    }
+    
+    public var urbn_bottomBorder: URBNBorder? {
+        return bottomBorder()
+    }
+    
+    private func urbn_borderView() -> URBNBorderView? {
+        if var borderView = objc_getAssociatedObject(self, &kURBNorderViewKey) as? URBNBorderView {
+            borderView = URBNBorderView(frame: self.bounds)
+            borderView.isOpaque = false
+            borderView.isUserInteractionEnabled = false
+            borderView.clearsContextBeforeDrawing = true
+            borderView.contentMode = .redraw
+            borderView.translatesAutoresizingMaskIntoConstraints = false
+            self.addSubview(borderView)
+            
+            let views = ["borderView" : borderView]
+            activateVFL(format: "V:|[borderView]|", options: .alignAllCenterX, metrics: nil, views: views)
+            activateVFL(format: "H:|[borderView]|", options: .alignAllCenterY, metrics: nil, views: views)
+            objc_setAssociatedObject(self, &kURBNorderViewKey, borderView, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            
+            return borderView
+        }
+        
+        return nil
+    }
+    
+    public func urbn_resetBorders() {
+        urbn_borderView()?.resetBorders()
+    }
+    
+    public func urbn_setBorder(withColor color: UIColor, width: CGFloat) {
+        urbn_leftBorder?.width = width
+        urbn_rightBorder?.width = width
+        urbn_topBorder?.width = width
+        urbn_bottomBorder?.width = width
+        urbn_leftBorder?.color = color
+        urbn_rightBorder?.color = color
+        urbn_topBorder?.color = color
+        urbn_bottomBorder?.color = color
+    }
+    
+    // MARK: Getters
+    private func leftBorder() -> URBNBorder? {
+        return self.urbn_borderView()?.urbn_LeftBorder()
+    }
+    
+    private func rightBorder() -> URBNBorder? {
+        return self.urbn_borderView()?.urbn_RightBorder()
+    }
+    
+    private func topBorder() -> URBNBorder? {
+        return self.urbn_borderView()?.urbn_TopBorder()
+    }
+    
+    private func bottomBorder() -> URBNBorder? {
+        return self.urbn_borderView()?.urbn_BottomBorder()
+    }
+}
 
 public class URBNBorder: NSObject {
     public var color = UIColor()
@@ -209,73 +278,4 @@ fileprivate class URBNBorderView: UIView {
     }
 }
 
-extension UIView {
-    public var urbn_leftBorder: URBNBorder? {
-        return leftBorder()
-    }
-    
-    public var urbn_rightBorder: URBNBorder? {
-        return rightBorder()
-    }
-    
-    public var urbn_topBorder: URBNBorder? {
-        return topBorder()
-    }
-    
-    public var urbn_bottomBorder: URBNBorder? {
-        return bottomBorder()
-    }
-    
-    private func urbn_borderView() -> URBNBorderView? {
-        if var borderView = objc_getAssociatedObject(self, &kURBNorderViewKey) as? URBNBorderView {
-            borderView = URBNBorderView(frame: self.bounds)
-            borderView.isOpaque = false
-            borderView.isUserInteractionEnabled = false
-            borderView.clearsContextBeforeDrawing = true
-            borderView.contentMode = .redraw
-            borderView.translatesAutoresizingMaskIntoConstraints = false
-            self.addSubview(borderView)
-            
-            let views = ["borderView" : borderView]
-            activateVFL(format: "V:|[borderView]|", options: .alignAllCenterX, metrics: nil, views: views)
-            activateVFL(format: "H:|[borderView]|", options: .alignAllCenterY, metrics: nil, views: views)
-            objc_setAssociatedObject(self, &kURBNorderViewKey, borderView, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-            
-            return borderView
-        }
-        
-        return nil
-    }
-    
-    public func urbn_resetBorders() {
-        urbn_borderView()?.resetBorders()
-    }
-    
-    public func urbn_setBorder(withColor color: UIColor, width: CGFloat) {
-        urbn_leftBorder?.width = width
-        urbn_rightBorder?.width = width
-        urbn_topBorder?.width = width
-        urbn_bottomBorder?.width = width
-        urbn_leftBorder?.color = color
-        urbn_rightBorder?.color = color
-        urbn_topBorder?.color = color
-        urbn_bottomBorder?.color = color
-    }
-    
-    // MARK: Getters
-    private func leftBorder() -> URBNBorder? {
-        return self.urbn_borderView()?.urbn_LeftBorder()
-    }
-    
-    private func rightBorder() -> URBNBorder? {
-        return self.urbn_borderView()?.urbn_RightBorder()
-    }
-    
-    private func topBorder() -> URBNBorder? {
-        return self.urbn_borderView()?.urbn_TopBorder()
-    }
-    
-    private func bottomBorder() -> URBNBorder? {
-        return self.urbn_borderView()?.urbn_BottomBorder()
-    }
-}
+fileprivate var kURBNorderViewKey = CChar()

--- a/URBNSwiftyConvenience/Classes/URBNBorders.swift
+++ b/URBNSwiftyConvenience/Classes/URBNBorders.swift
@@ -25,7 +25,7 @@ fileprivate class URBNBorderView: UIView {
     private final let width = "width"
     private final let color = "color"
     private final let insets = "insets"
-
+    
     convenience init() {
         self.init()
     }
@@ -61,10 +61,10 @@ fileprivate class URBNBorderView: UIView {
     // MARK: Clear
     private func clearAllBorders() {
         guard
-            let leftBorder = self.bv_leftBorder,
-            let rightBorder = self.bv_rightBorder,
-            let topBorder = self.bv_topBorder,
-            let bottomBorder = self.bv_bottomBorder else {
+            let leftBorder = bv_leftBorder,
+            let rightBorder = bv_rightBorder,
+            let topBorder = bv_topBorder,
+            let bottomBorder = bv_bottomBorder else {
                 return
         }
         
@@ -73,10 +73,10 @@ fileprivate class URBNBorderView: UIView {
         unregisterKVO(forBorder: topBorder)
         unregisterKVO(forBorder: bottomBorder)
         
-        self.bv_leftBorder = nil
-        self.bv_rightBorder = nil
-        self.bv_topBorder = nil
-        self.bv_bottomBorder = nil
+        bv_leftBorder = nil
+        bv_rightBorder = nil
+        bv_topBorder = nil
+        bv_bottomBorder = nil
     }
     
     fileprivate func resetBorders() {
@@ -85,29 +85,29 @@ fileprivate class URBNBorderView: UIView {
     }
     
     // MARK: Border Check for Nil
-    private func urbn_LeftBorder() -> URBNBorder? {
-        guard var leftBorder = urbn_leftBorder else { return nil }
+    fileprivate func urbn_LeftBorder() -> URBNBorder? {
+        guard var leftBorder = bv_leftBorder else { return nil }
         leftBorder = configuredBorder()
         
         return leftBorder
     }
     
-    private func urbn_RightBorder() -> URBNBorder? {
-        guard var rightBorder = urbn_rightBorder else { return nil }
+    fileprivate func urbn_RightBorder() -> URBNBorder? {
+        guard var rightBorder = bv_rightBorder else { return nil }
         rightBorder = configuredBorder()
         
         return rightBorder
     }
     
-    private func urbn_TopBorder() -> URBNBorder? {
-        guard var topBorder = urbn_topBorder else { return nil }
+    fileprivate func urbn_TopBorder() -> URBNBorder? {
+        guard var topBorder = bv_topBorder else { return nil }
         topBorder = configuredBorder()
         
         return topBorder
     }
     
-    private func urbn_BottomBorder() -> URBNBorder? {
-        guard var bottomBorder = urbn_bottomBorder else { return nil }
+    fileprivate func urbn_BottomBorder() -> URBNBorder? {
+        guard var bottomBorder = bv_bottomBorder else { return nil }
         bottomBorder = configuredBorder()
         
         return bottomBorder
@@ -211,26 +211,22 @@ fileprivate class URBNBorderView: UIView {
 
 extension UIView {
     public var urbn_leftBorder: URBNBorder? {
-        return self.urbn_leftBorder
+        return leftBorder()
     }
     
     public var urbn_rightBorder: URBNBorder? {
-        return self.urbn_rightBorder
+        return rightBorder()
     }
     
     public var urbn_topBorder: URBNBorder? {
-        return self.urbn_topBorder
+        return topBorder()
     }
     
     public var urbn_bottomBorder: URBNBorder? {
-        return self.urbn_bottomBorder
+        return bottomBorder()
     }
     
     private func urbn_borderView() -> URBNBorderView? {
-        if self == URBNBorderView() {
-            return self as? URBNBorderView
-        }
-
         if var borderView = objc_getAssociatedObject(self, &kURBNorderViewKey) as? URBNBorderView {
             borderView = URBNBorderView(frame: self.bounds)
             borderView.isOpaque = false
@@ -247,7 +243,7 @@ extension UIView {
             
             return borderView
         }
-
+        
         return nil
     }
     
@@ -268,18 +264,18 @@ extension UIView {
     
     // MARK: Getters
     private func leftBorder() -> URBNBorder? {
-        return self.urbn_borderView()?.bv_leftBorder
+        return self.urbn_borderView()?.urbn_LeftBorder()
     }
     
     private func rightBorder() -> URBNBorder? {
-        return self.urbn_borderView()?.bv_rightBorder
+        return self.urbn_borderView()?.urbn_RightBorder()
     }
     
     private func topBorder() -> URBNBorder? {
-        return self.urbn_borderView()?.bv_topBorder
+        return self.urbn_borderView()?.urbn_TopBorder()
     }
     
     private func bottomBorder() -> URBNBorder? {
-        return self.urbn_borderView()?.bv_bottomBorder
+        return self.urbn_borderView()?.urbn_BottomBorder()
     }
 }

--- a/URBNSwiftyConvenience/Classes/URBNBorders.swift
+++ b/URBNSwiftyConvenience/Classes/URBNBorders.swift
@@ -11,8 +11,8 @@ import Foundation
 fileprivate var kURBNorderViewKey = CChar()
 
 public class URBNBorder: NSObject {
-    public let color = UIColor()
-    public let width = CGFloat()
+    public var color = UIColor()
+    public var width = CGFloat()
     public let insets = UIEdgeInsets()
 }
 
@@ -252,11 +252,18 @@ extension UIView {
     }
     
     public func urbn_resetBorders() {
-        
+        urbn_borderView()?.urbn_resetBorders()
     }
     
     public func urbn_setBorder(withColor color: UIColor, width: CGFloat) {
-        
+        urbn_leftBorder?.width = width
+        urbn_rightBorder?.width = width
+        urbn_topBorder?.width = width
+        urbn_bottomBorder?.width = width
+        urbn_leftBorder?.color = color
+        urbn_rightBorder?.color = color
+        urbn_topBorder?.color = color
+        urbn_bottomBorder?.color = color
     }
     
 }

--- a/URBNSwiftyConvenience/Classes/URBNBorders.swift
+++ b/URBNSwiftyConvenience/Classes/URBNBorders.swift
@@ -20,7 +20,31 @@ fileprivate class URBNBorderView: UIView {
     let urbn_rightBorder: URBNBorder?
     let urbn_bottomBorder: URBNBorder?
     
+    private final let width = "width"
+    private final let color = "color"
+    private final let insets = "insets"
+    
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+   
+    // MARK: KVO
+    func configuredBorder() -> URBNBorder {
+        let border = URBNBorder()
+        border.addObserver(self, forKeyPath: width, options: .new, context: nil)
+        border.addObserver(self, forKeyPath: color, options: .new, context: nil)
+        border.addObserver(self, forKeyPath: insets, options: .new, context: nil)
+        
+        return border
+    }
+    
+    func unregisterKVO(forBorder border: URBNBorder) {
+        border.removeObserver(self, forKeyPath: width)
+        border.removeObserver(self, forKeyPath: color)
+        border.removeObserver(self, forKeyPath: insets)
+    }
+    
+    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+        setNeedsDisplay()
     }
 }


### PR DESCRIPTION
The purpose of this PR is to ensure `URBNSwiftyConvenience` is compatible with `WhiteLabel`. The missing function was `urbn_setBorder` which required the following:

- New class of type `URBNBorder`
- Private class of type `URBNBorderView`
- Extension on `UIView` with four new properties & two functions (including `urbn_setBorder`)

Original Objective-C [header](https://github.com/urbn/URBNConvenience/blob/master/Pod/Classes/UIView%2BURBNBorders.h) & [implementation](https://github.com/urbn/URBNConvenience/blob/master/Pod/Classes/UIView%2BURBNBorders.m) files.