### PR TITLE
Add hexString support to UIColor

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - URBNSwiftyConvenience (0.1.0)
+  - URBNSwiftyConvenience (0.2.0)
 
 DEPENDENCIES:
   - URBNSwiftyConvenience (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  URBNSwiftyConvenience: 7863fa06c58e12c7a6d3301375488ce567735326
+  URBNSwiftyConvenience: 39249fc800bef0962ac99172007aeaf09fc150dd
 
 PODFILE CHECKSUM: b1a00df3b001c7558afb1929e95f3522d9d92a6b
 

--- a/Example/Pods/Local Podspecs/URBNSwiftyConvenience.podspec.json
+++ b/Example/Pods/Local Podspecs/URBNSwiftyConvenience.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "URBNSwiftyConvenience",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "summary": "Convenience methods for commonly used iOS frameworks",
   "homepage": "https://github.com/urbn/URBNSwiftyConvenience",
   "license": "MIT",
@@ -9,7 +9,7 @@
   },
   "source": {
     "git": "https://github.com/urbn/URBNSwiftyConvenience.git",
-    "tag": "0.1.0"
+    "tag": "0.2.0"
   },
   "platforms": {
     "ios": "10.0",

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - URBNSwiftyConvenience (0.1.0)
+  - URBNSwiftyConvenience (0.2.0)
 
 DEPENDENCIES:
   - URBNSwiftyConvenience (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  URBNSwiftyConvenience: 7863fa06c58e12c7a6d3301375488ce567735326
+  URBNSwiftyConvenience: 39249fc800bef0962ac99172007aeaf09fc150dd
 
 PODFILE CHECKSUM: b1a00df3b001c7558afb1929e95f3522d9d92a6b
 

--- a/Example/Pods/Target Support Files/URBNSwiftyConvenience/Info.plist
+++ b/Example/Pods/Target Support Files/URBNSwiftyConvenience/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.1.0</string>
+  <string>0.2.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -10,6 +10,16 @@ class Tests: XCTestCase {
         XCTAssertEqual(UIColor(rgb: 0x0000FF), UIColor.blue)
         XCTAssertEqual(UIColor(rgb: 0x00FFFF), UIColor.cyan)
         XCTAssertEqual(UIColor(rgb: 0xFFFF00), UIColor.yellow)
+        
+        XCTAssertEqual(UIColor(hexString: "FF0000"), UIColor.red)
+        XCTAssertEqual(UIColor(hexString: "#00FF00"), UIColor.green)
+        XCTAssertEqual(UIColor(hexString: "0000FF"), UIColor.blue)
+        XCTAssertEqual(UIColor(hexString: "#00FFFF"), UIColor.cyan)
+        XCTAssertEqual(UIColor(hexString: "FFFF00"), UIColor.yellow)
+
+        XCTAssertEqual(UIColor(hexString: "FFFF0"), UIColor(rgb: 0))
+        XCTAssertEqual(UIColor(hexString: "#FFFF0"), UIColor(rgb: 0))
+        XCTAssertEqual(UIColor(hexString: "Jerkface"), UIColor(rgb: 0))
     }
 }
 

--- a/URBNSwiftyConvenience/Classes/UIColorConvenience.swift
+++ b/URBNSwiftyConvenience/Classes/UIColorConvenience.swift
@@ -8,8 +8,33 @@
 
 import Foundation
 
+extension CharacterSet {
+    public static var hexValues: CharacterSet {
+        return CharacterSet(charactersIn: "0123456789ABCDEFabcdef")
+    }
+}
+
+
 extension UIColor {
     
+    public convenience init(hexString: String) {
+        let sanitized = hexString.components(separatedBy: CharacterSet.hexValues.inverted).joined()
+        let count = sanitized.characters.count
+        var rgb: UInt32 = 0
+        
+        if (count == 6 || count == 8), Scanner(string: sanitized).scanHexInt32(&rgb) {
+            if sanitized.characters.count == 6 {
+                self.init(rgb: rgb)
+            }
+            else {
+                self.init(rgba: rgb)
+            }
+        }
+        else {
+            self.init(rgb: 0)
+        }
+    }
+
     /// Create a color from RGBA values as UInt8
     ///
     /// This allows creation of colors like:
@@ -38,7 +63,7 @@ extension UIColor {
     /// `UIColor(rgb: 0xFF0000)`
     ///
     /// - Parameter rgb: an integer representing RGB values, Hex work the best
-    public convenience init(rgb: Int) {
+    public convenience init(rgb: UInt32) {
         if rgb > 0xFFFFFF { // outside RGB
             self.init(white: 0.0, alpha: 1.0)
         }
@@ -58,18 +83,13 @@ extension UIColor {
     /// - Parameter rgba: an integer representing RGB values, Hex work the best
     ///
     /// - Notes:
-    ///   -  Has to be Int64 to support 0xFFFFFFFF on 32 bit devices
-    public convenience init(rgba: Int64) {
-        if rgba > 0xFFFFFFFF { // outside RGBA
-            self.init(white: 0.0, alpha: 1.0)
-        }
-        else {
-            let r = UInt8((rgba & 0xFF000000) >> 24)
-            let g = UInt8((rgba & 0x00FF0000) >> 16)
-            let b = UInt8((rgba & 0x0000FF00) >> 8)
-            let a = UInt8(rgba & 0x000000FF)
-            self.init(redInt: r, greenInt: g, blueInt: b, alphaInt: a)
-        }
+    ///   -  Has to be UInt32 to support 0xFFFFFFFF on 32 bit devices
+    public convenience init(rgba: UInt32) {
+        let r = UInt8((rgba & 0xFF000000) >> 24)
+        let g = UInt8((rgba & 0x00FF0000) >> 16)
+        let b = UInt8((rgba & 0x0000FF00) >> 8)
+        let a = UInt8(rgba & 0x000000FF)
+        self.init(redInt: r, greenInt: g, blueInt: b, alphaInt: a)
     }
     
     /// Returns a random color


### PR DESCRIPTION
Apparently, we get a string back as hex values for color swatches. This adds support for those.