### PR TITLE
Add tvOS since URBNSwiftyConvenience supports it

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - URBNSwiftyConvenience (0.3.3)
+  - URBNSwiftyConvenience (0.4.0)
 
 DEPENDENCIES:
   - URBNSwiftyConvenience (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  URBNSwiftyConvenience: c8c756be98f345922556bfc1001c379056ccc933
+  URBNSwiftyConvenience: 379718f4415e1c73dcaa3e18ae0a2fafcecfbbcf
 
 PODFILE CHECKSUM: b1a00df3b001c7558afb1929e95f3522d9d92a6b
 

--- a/Example/Pods/Local Podspecs/URBNSwiftyConvenience.podspec.json
+++ b/Example/Pods/Local Podspecs/URBNSwiftyConvenience.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "URBNSwiftyConvenience",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "summary": "Convenience methods for commonly used iOS frameworks",
   "homepage": "https://github.com/urbn/URBNSwiftyConvenience",
   "license": "MIT",
@@ -9,7 +9,7 @@
   },
   "source": {
     "git": "https://github.com/urbn/URBNSwiftyConvenience.git",
-    "tag": "0.3.3"
+    "tag": "0.4.0"
   },
   "platforms": {
     "ios": "10.0",

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - URBNSwiftyConvenience (0.3.3)
+  - URBNSwiftyConvenience (0.4.0)
 
 DEPENDENCIES:
   - URBNSwiftyConvenience (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  URBNSwiftyConvenience: c8c756be98f345922556bfc1001c379056ccc933
+  URBNSwiftyConvenience: 379718f4415e1c73dcaa3e18ae0a2fafcecfbbcf
 
 PODFILE CHECKSUM: b1a00df3b001c7558afb1929e95f3522d9d92a6b
 

--- a/Example/Pods/Target Support Files/URBNSwiftyConvenience/Info.plist
+++ b/Example/Pods/Target Support Files/URBNSwiftyConvenience/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.3.3</string>
+  <string>0.4.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/URBNSwiftyConvenience/Classes/UIViewAnchorConvenience.swift
+++ b/URBNSwiftyConvenience/Classes/UIViewAnchorConvenience.swift
@@ -11,7 +11,7 @@ import Foundation
 ///
 extension UIView {
     var safeAreaBottomAnchor: NSLayoutYAxisAnchor {
-        if #available(iOS 11, *) {
+        if #available(iOS 11, tvOS 11, *) {
             return safeAreaLayoutGuide.bottomAnchor
         }
         else {
@@ -20,7 +20,7 @@ extension UIView {
     }
     
     var safeAreaCenterXAnchor: NSLayoutXAxisAnchor {
-        if #available(iOS 11, *) {
+        if #available(iOS 11, tvOS 11, *) {
             return safeAreaLayoutGuide.centerXAnchor
         }
         else {
@@ -29,7 +29,7 @@ extension UIView {
     }
     
     var safeAreaCenterYAnchor: NSLayoutYAxisAnchor {
-        if #available(iOS 11, *) {
+        if #available(iOS 11, tvOS 11, *) {
             return safeAreaLayoutGuide.centerYAnchor
         }
         else {
@@ -38,7 +38,7 @@ extension UIView {
     }
     
     var safeAreaHeightAnchor: NSLayoutDimension {
-        if #available(iOS 11, *) {
+        if #available(iOS 11, tvOS 11, *) {
             return safeAreaLayoutGuide.heightAnchor
         }
         else {
@@ -47,7 +47,7 @@ extension UIView {
     }
     
     var safeAreaLeadingAnchor: NSLayoutXAxisAnchor {
-        if #available(iOS 11, *) {
+        if #available(iOS 11, tvOS 11, *) {
             return safeAreaLayoutGuide.leadingAnchor
         }
         else {
@@ -56,7 +56,7 @@ extension UIView {
     }
     
     var safeAreaLeftAnchor: NSLayoutXAxisAnchor {
-        if #available(iOS 11, *) {
+        if #available(iOS 11, tvOS 11, *) {
             return safeAreaLayoutGuide.leftAnchor
         }
         else {
@@ -65,7 +65,7 @@ extension UIView {
     }
     
     var safeAreaRightAnchor: NSLayoutXAxisAnchor {
-        if #available(iOS 11, *) {
+        if #available(iOS 11, tvOS 11, *) {
             return safeAreaLayoutGuide.rightAnchor
         }
         else {
@@ -74,7 +74,7 @@ extension UIView {
     }
     
     var safeAreaTopAnchor: NSLayoutYAxisAnchor {
-        if #available(iOS 11, *) {
+        if #available(iOS 11, tvOS 11, *) {
             return safeAreaLayoutGuide.topAnchor
         }
         else {
@@ -83,7 +83,7 @@ extension UIView {
     }
     
     var safeAreaTrailingAnchor: NSLayoutXAxisAnchor {
-        if #available(iOS 11, *) {
+        if #available(iOS 11, tvOS 11, *) {
             return safeAreaLayoutGuide.trailingAnchor
         }
         else {
@@ -92,7 +92,7 @@ extension UIView {
     }
     
     var safeAreaWidthAnchor: NSLayoutDimension {
-        if #available(iOS 11, *) {
+        if #available(iOS 11, tvOS 11, *) {
             return safeAreaLayoutGuide.widthAnchor
         }
         else {


### PR DESCRIPTION
Add tvOS since URBNSwiftyConvenience supports it and we can’t pass `pod spec lint` without specifying it:

```
- ERROR | [tvOS] xcodebuild: Returned an unsuccessful exit code.
- ERROR | [tvOS] xcodebuild:  URBNSwiftyConvenience/URBNSwiftyConvenience/Classes/UIViewAnchorConvenience.swift:15:20: error: 'safeAreaLayoutGuide' is only available on tvOS 11.0 or newer
```