### PR TITLE
UIOS-2366, updated .tintedImage convenience to take the scale of screen

### DIFF
--- a/URBNSwiftyConvenience/Classes/UIImageConvenience.swift
+++ b/URBNSwiftyConvenience/Classes/UIImageConvenience.swift
@@ -13,7 +13,7 @@ public extension UIImage {
     public typealias URBNConvenienceImageDrawBlock = (_ rect: CGRect, _ context: CGContext) -> ()
     
     public func tintedImage(color: UIColor) -> UIImage? {
-        UIGraphicsBeginImageContext(self.size)
+        UIGraphicsBeginImageContextWithOptions(self.size, false, 0.0)
         let context = UIGraphicsGetCurrentContext()
 
         context?.scaleBy(x: 1.0, y: -1.0)


### PR DESCRIPTION
[UIOS-2366](https://urbnit.atlassian.net/browse/UIOS-2366)
- The purpose of this PR is to update UIImageConvenience method .tintedImage
- The '0.0' needed to be added to option so that it takes the scale of the screen and return the correct image scale, or else it will be returned pixelated